### PR TITLE
Reboot instead to ensure consistent fstab mount

### DIFF
--- a/roles/mount_drive/handlers/main.yml
+++ b/roles/mount_drive/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Reboot to mount fstab drive
+  ansible.builtin.reboot:

--- a/roles/mount_drive/tasks/main.yml
+++ b/roles/mount_drive/tasks/main.yml
@@ -26,14 +26,10 @@
     opts: "defaults,uid={{ mount_owner }},gid={{ mount_group }},umask={{ mount_umask }}"
     state: "mounted"
     backup: yes
+  notify: Reboot to mount fstab drive
 
-- name: Ensure the external drive is mounted
-  ansible.posix.mount:
-    path: "{{ mount_point }}"
-    src: "{{ device_name }}"
-    fstype: "{{ filesystem_type }}"
-    opts: "defaults,uid={{ mount_owner }},gid={{ mount_group }},umask={{ mount_umask }}"
-    state: mounted
+- name: Flush handlers to ensure drive mounted
+  meta: flush_handlers
 
 - name: Ensure the target directory for symlink exists
   ansible.builtin.file:


### PR DESCRIPTION
Previous mounting method was not identical to the one fstab uses,
this resulted in a different state, depending on whether it was the
first or second boot

Fixes #2
